### PR TITLE
fix: acquire token from url

### DIFF
--- a/src/routes/connect.tsx
+++ b/src/routes/connect.tsx
@@ -5,7 +5,7 @@ export const Route = createFileRoute('/connect')({
   loader: async ctx => {
     if (!ctx.location.hash) throw "no hash"
 
-    const search = new URLSearchParams(location.hash)
+    const search = new URLSearchParams(ctx.location.hash)
     const token = search.get("access_token");
     if (!token) throw "no token"
 


### PR DESCRIPTION
was getting `no token`